### PR TITLE
Prepare for crate publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+#
+# While our "example" application has the platform-specific code,
+# for simplicity we are compiling and testing everything on the Ubuntu environment only.
+# For multi-OS testing see the `cross.yml` workflow.
+
+on: [pull_request]
+
+name: CI
+
+jobs:
+  check:
+    if: github.event.pull_request.draft == false # Don't run if PR is draft
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  # Unsurprisingly missing tests while tests are missing :oooo
+
+  lints:
+    if: github.event.pull_request.draft == false # Don't run if PR is draft
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Madhav Kumar"]
 description = "An SDK to interact with pieces of the original Line Rider game"
-repository = "https://github.com/kumar-ish/line-rider-rust/"
+repository = "https://github.com/kumar-ish/draw-lr/"
+readme = "README.md"
 license = "MIT License"
 keywords = ["gamedev", "graphics", "line_rider", "line-rider", "lr"]
+exclude = ["**/*.json"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
 # Line Rider SDK
 
 This is a library to be able to build on [Line Rider](https://www.linerider.com/); note that this is to interact with the original game, and not an extension. 
+
+## Usage
+
+You can use the crate by instantiating a game (of type `draw_lr::Game`) and adding pieces on top of it (lines, layers, riders) using the crate. You can then write the game to a track JSON file and play with that on the game by uploading it.
+
+```rust
+fn main() {
+    use draw_lr::*;
+    use draw_lr::extension::*;
+    
+    let mut game = Game::new();
+
+    let polygon = thick_polygon_lines(10, 40, None, None, 1, 1);
+    game.add_lines(polygon.iter());
+
+    let riders: Vec<Rider> = create_riders(
+        // Number of riders
+        4,
+        // Start pos
+        CoordOptions::Rand,
+        // Start speed
+        CoordOptions::Rand,
+        // Remountable
+        None,
+    );
+    game.add_riders(riders.iter());
+
+    game.write_to_file("decagon.track.json").ok();
+}
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
-//! Crate to make maps & interact with the [Line Rider](https://linerider.com) game.
+//! Crate to make maps & interact with the [Line Rider](https://linerider.com) game. The base module in the crate contains the
+//! main object definitions and the extension(s) build on top of them.
 
 use std::fmt::Debug;
 use std::fs;
@@ -157,13 +158,13 @@ pub mod extension {
         Rand,
         /// Random coordinates over range
         RandRange(Coordinates, Coordinates),
-        /// Specify exact coordinates (Some) or use default (None)
+        /// Specify exact coordinates (`Some`) or use default (`None`)
         Other(Option<Coordinates>),
         /// Evenly space out coordinates over range
         EvenlySpaced(Coordinates, Coordinates),
     }
 
-    /// Adds `n` riders to a given `game`, at some `start_position` and `speed_range`; all with characteristic `remountable`.
+    /// Creates a list of `n` riders, at some `start_position` and `speed_range`; all with characteristic `remountable`.
     pub fn create_riders(n: usize, start_position: CoordOptions, speed_range: CoordOptions, remountable: Option<usize>) -> Vec<Rider> {
         fn check_min_max(min: f64, max: f64) {
             // Min/max checks might not be strictly necessary, but may prevent bugs.


### PR DESCRIPTION
## Motivation

There's some pieces that should be edited/fixed/added before an initial crates publish -- namely: documentation, some amount of CI/CD, metadata things with package-publishing. This PR should cover them all before an initial `0.0.1` publish. 